### PR TITLE
GZ-10 Added type validation check for Python

### DIFF
--- a/.github/workflows/python-typecheck.yml
+++ b/.github/workflows/python-typecheck.yml
@@ -1,0 +1,21 @@
+name: Check Python Types
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Type Check
+    runs-on: ubuntu-18.04
+    steps:
+      - name: clone-repo
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: install-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.5'
+      - name: install-requirements
+        run: python -m pip install -r requirements-dev.txt
+      - name: style-check
+        run: bash check-types.sh

--- a/check-types.sh
+++ b/check-types.sh
@@ -1,0 +1,1 @@
+mypy src/grizzzly --ignore-missing-imports --install-types --non-interactive


### PR DESCRIPTION
## Description
Created a type validation script for Python

* Closes #10 

## Testing
You can run the type validation using the following commands:
```commandline
pip install -r requirements.txt
bash check-types.sh
```

## Evaluation
- [X] Make sure this PR contains a single feature
- [X] Make sure this PR solves a Github Issue
- [x] Python Specific:
    * Make sure you added in-code documentation
    * You added Python type hints for parameters and return types