### PR TITLE
GZ-39 Download endpoint (mockup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This document contains a changelog of the relevant `grizzzly` releases.
 
 --
 
+## 0.4.0 - Grizzzly download endpoint (mockup) and client
+
+* Issue: #39
+* Version: `0.4.0`
+* Feature Scope: `Minor`
+* Date: `2022-04-15`
+
+## Description
+
+This is a simple feature that adds:
+* A first mockup of the download endpoint (backend).
+* The `download_dataset` function client.
+
+--
+
 ## 0.2.0 - Grizzzly backend scaffold
 
 * Issue: #33

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fire==0.4.0
 Flask==2.1.1
 waitress==2.1.1
-
+pandas>=1.4.0,<2.0.0
+requests>=2.21.0,<2.30.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as file:
 
 setup(
     name="grizzzly",
-    version="0.3.0",
+    version="0.4.0",
     description="This is your favorite data sharing library! Works great with pandas.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/src/grizzzly/__init__.py
+++ b/src/grizzzly/__init__.py
@@ -1,3 +1,5 @@
+from grizzzly.client.download import download_dataset
+
 
 def start_cli():
     import fire

--- a/src/grizzzly/client/download.py
+++ b/src/grizzzly/client/download.py
@@ -1,0 +1,18 @@
+import requests
+import pandas as pd
+
+from grizzzly.settings import (
+    GZ_ENDPOINT_ALIAS,
+    GZ_FLASK_HOST,
+    GZ_FLASK_PORT,
+)
+
+
+
+def download_dataset(name: str) -> pd.DataFrame:
+    url = f"http://{GZ_FLASK_HOST}:{GZ_FLASK_PORT}/download"
+    response = requests.get(GZ_ENDPOINT_ALIAS["download-dataset"])
+    if not response.ok:
+        raise ValueError("There was a problem while getting the dataset")
+    data = response.json()
+    return pd.DataFrame(data)

--- a/src/grizzzly/client/download.py
+++ b/src/grizzzly/client/download.py
@@ -1,16 +1,22 @@
+from typing import Optional
+
 import requests
 import pandas as pd
 
 from grizzzly.settings import (
+    get_logger,
     GZ_ENDPOINT_ALIAS,
     GZ_FLASK_HOST,
     GZ_FLASK_PORT,
 )
 
 
+logger = get_logger(__name__)
 
-def download_dataset(name: str) -> pd.DataFrame:
-    url = f"http://{GZ_FLASK_HOST}:{GZ_FLASK_PORT}/download"
+
+def download_dataset(name: Optional[str] = None) -> pd.DataFrame:
+    if not name:
+        logger.warning("Name was not provided; retrieving the default dataset")
     response = requests.get(GZ_ENDPOINT_ALIAS["download-dataset"])
     if not response.ok:
         raise ValueError("There was a problem while getting the dataset")

--- a/src/grizzzly/server/__init__.py
+++ b/src/grizzzly/server/__init__.py
@@ -3,9 +3,11 @@ from flask import Flask
 
 # Import the endpoint
 from grizzzly.server.api_hello import api_hello as hello
+from grizzzly.server.api_download import api_download as download
 
 # Flask application instance
 app = Flask(__name__)
 
 # Register the endpoints
 app.register_blueprint(hello)
+app.register_blueprint(download)

--- a/src/grizzzly/server/api_download.py
+++ b/src/grizzzly/server/api_download.py
@@ -17,5 +17,5 @@ api_download = Blueprint(
 def download():
     # TODO: This is currently just a mockup
     df = pd.read_csv(GZ_API_DEFAULT_DOWNLOAD_DATASET)
-    payload = list( df.T.to_dict().values())
+    payload = list(df.T.to_dict().values())
     return jsonify(payload)

--- a/src/grizzzly/server/api_download.py
+++ b/src/grizzzly/server/api_download.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from flask import Blueprint, request, jsonify
+
+from grizzzly.settings import GZ_API_DEFAULT_DOWNLOAD_DATASET
+
+
+# Create endpoint blueprint
+api_download = Blueprint(
+    name="download",
+    import_name=__name__,
+    url_prefix="/download"
+)
+
+
+# Register endpoints
+@api_download.route("/", methods=["GET"])
+def download():
+    # TODO: This is currently just a mockup
+    df = pd.read_csv(GZ_API_DEFAULT_DOWNLOAD_DATASET)
+    payload = list( df.T.to_dict().values())
+    return jsonify(payload)

--- a/src/grizzzly/settings.py
+++ b/src/grizzzly/settings.py
@@ -27,8 +27,8 @@ GZ_FLASK_SSL = os.environ.get(
 GZ_API_URL = f"http{'s' if GZ_FLASK_SSL else ''}://{GZ_FLASK_HOST}:{GZ_FLASK_PORT}"
 
 GZ_ENDPOINT_ALIAS = {
-    "hello": posixpath.join(GZ_API_URL, "hello") ,
-    "download-dataset": posixpath.join(GZ_API_URL, "download"), 
+    "hello": posixpath.join(GZ_API_URL, "hello"),
+    "download-dataset": posixpath.join(GZ_API_URL, "download"),
 }
 
 GZ_API_DEFAULT_DOWNLOAD_DATASET = os.environ.get(

--- a/src/grizzzly/settings.py
+++ b/src/grizzzly/settings.py
@@ -1,9 +1,12 @@
 import logging
+import posixpath
 import os
 
 from logging.config import dictConfig
 from typing import Dict, Optional
 
+
+# Backend
 
 GZ_FLASK_HOST = os.environ.get(
     "GZ_FLASK_HOST",
@@ -14,6 +17,23 @@ GZ_FLASK_HOST = os.environ.get(
 GZ_FLASK_PORT = os.environ.get(
     "GZ_FLASK_PORT",
     default="9999",
+)
+
+GZ_FLASK_SSL = os.environ.get(
+    "GZ_FLASK_SSL",
+    default="false",
+).lower().startswith("t")
+
+GZ_API_URL = f"http{'s' if GZ_FLASK_SSL else ''}://{GZ_FLASK_HOST}:{GZ_FLASK_PORT}"
+
+GZ_ENDPOINT_ALIAS = {
+    "hello": posixpath.join(GZ_API_URL, "hello") ,
+    "download-dataset": posixpath.join(GZ_API_URL, "download"), 
+}
+
+GZ_API_DEFAULT_DOWNLOAD_DATASET = os.environ.get(
+    "GZ_API_DEFAULT_DOWNLOAD_DATASET",
+    default="https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv"
 )
 
 


### PR DESCRIPTION
## Description

This PR implements a simple download method in both the backend and the client.

* Closes #39 

## Testing

Start the grizzzly server:

```commandline
$ grizzzly backend run 
```

Run the following code in a `ipython` session:

```python
import grizzzly as gz

df = gz.download_dataset(name="default")
df
```

## Evaluation
- [X] Make sure this PR contains a single feature
- [X] Make sure this PR solves a Github Issue
- [X] Python Specific:
    * Make sure you added in-code documentation
    * You added Python type hints for parameters and return types