### PR TITLE
GZ-44 Fix download server/client implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ This document contains a changelog of the relevant `grizzzly` releases.
 
 --
 
+## 0.6.0 - Grizzzly download endpoint and client implementation
+
+* Issue: #44
+* Version: `0.6.0`
+* Feature Scope: `Minor`
+* Date: `2022-04-28`
+
+### Description
+
+This feature implements a minimal download functionality in both the backend & client. 
+
+-- 
+
+## 0.5.0 - Grizzzly upload endpoint and client
+
+* Issue: #38
+* Version: `0.5.0`
+* Feature Scope: `Minor`
+* Date: `2022-04-15`
+
+### Description
+
+This feature implements a minimal upload functionality in both the backend & client.
+
+--
+
 ## 0.4.0 - Grizzzly download endpoint (mockup) and client
 
 * Issue: #39
@@ -11,7 +37,7 @@ This document contains a changelog of the relevant `grizzzly` releases.
 * Feature Scope: `Minor`
 * Date: `2022-04-15`
 
-## Description
+### Description
 
 This is a simple feature that adds:
 * A first mockup of the download endpoint (backend).

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as file:
 
 setup(
     name="grizzzly",
-    version="0.5.0",
+    version="0.6.0",
     description="This is your favorite data sharing library! Works great with pandas.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/src/grizzzly/cli.py
+++ b/src/grizzzly/cli.py
@@ -1,11 +1,17 @@
 import time
-from grizzzly.settings import get_logger
 from typing import Optional
 
+import pandas as pd
 
+from grizzzly.client import (
+    download_dataset,
+    upload_dataset,
+)
 from grizzzly.settings import (
+    get_logger,
     GZ_FLASK_HOST,
     GZ_FLASK_PORT,
+    GZ_API_DEFAULT_DOWNLOAD_DATASET,
 )
 
 
@@ -57,3 +63,19 @@ class CLI:
         logger.warning("This is a warning log!")
         logger.error("This is an error log!")
         print(f"Hello, {name}!")
+
+    def upload_default(self, name: str, author: str):
+        df = pd.read_csv(GZ_API_DEFAULT_DOWNLOAD_DATASET)
+        upload_dataset(
+            name=name,
+            df=df,
+            author=author,
+        )
+
+    def download(self, name: str, author: str, limit: Optional[int] = None) -> str:
+        df = download_dataset(
+            name=name,
+            author=author
+        )
+        subset = df if limit is None else df.head(limit)
+        return subset.to_string()

--- a/src/grizzzly/client/__init__.py
+++ b/src/grizzzly/client/__init__.py
@@ -1,0 +1,2 @@
+from .download import download_dataset
+from .upload import upload_dataset

--- a/src/grizzzly/client/download.py
+++ b/src/grizzzly/client/download.py
@@ -12,10 +12,16 @@ from grizzzly.settings import (
 logger = get_logger(__name__)
 
 
-def download_dataset(name: Optional[str] = None) -> pd.DataFrame:
+def download_dataset(author: str, name: str) -> pd.DataFrame:
     if not name:
         logger.warning("Name was not provided; retrieving the default dataset")
-    response = requests.get(GZ_ENDPOINT_ALIAS["download-dataset"])
+    response = requests.get(
+        GZ_ENDPOINT_ALIAS["download-dataset"],
+        params={
+            "author": author,
+            "name": name,
+        }
+    )
     if not response.ok:
         raise ValueError("There was a problem while getting the dataset")
     data = response.json()

--- a/src/grizzzly/server/api_download.py
+++ b/src/grizzzly/server/api_download.py
@@ -1,7 +1,12 @@
+import os
+
 import pandas as pd
 from flask import Blueprint, request, jsonify
 
-from grizzzly.settings import GZ_API_DEFAULT_DOWNLOAD_DATASET
+from grizzzly.settings import (
+    GZ_API_DEFAULT_DOWNLOAD_DATASET,
+    GZ_DATASET_STORAGE_PATH,
+)
 
 
 # Create endpoint blueprint
@@ -15,7 +20,25 @@ api_download = Blueprint(
 # Register endpoints
 @api_download.route("/", methods=["GET"])
 def download():
-    # TODO: This is currently just a mockup
-    df = pd.read_csv(GZ_API_DEFAULT_DOWNLOAD_DATASET)
+    # Global parameters on the query string
+    params = request.args.to_dict()
+    # Dataset parameters
+    dataset_author = params.get("author")
+    dataset_name = params.get("name")
+    # Verify if both author and dataset name are provided
+    if not all([dataset_author, dataset_name]):
+        raise ValueError(
+            "You should provide both dataset name & author."
+        )
+    # Re-build the dataset path
+    dataset_path = os.path.join(
+        GZ_DATASET_STORAGE_PATH,
+        dataset_author,
+        dataset_name
+    )
+    # Read the dataset back into memory
+    # TODO: Do it by chunks!
+    df = pd.read_parquet(dataset_path)
+    # Transform the dataset into a JSON
     payload = list(df.T.to_dict().values())
     return jsonify(payload)


### PR DESCRIPTION
## Description

This PR implements the backend/client download functionality.

* Closes #44 

## Testing

Start the server:

```commandline
$ grizzzly backend run --debug
```

Upload the testing dataset:

```commandline
$ grizzzly upload-default --name my_dataset --author test
```

Test by running:

```commandline
$ tree test/my_dataset
```

```text
test/my_dataset
└── 05153d91-1717-5c86-9e10-5425307215e9
    ├── _common_metadata
    ├── gz_chunk_part=0
    │   └── part.0.parquet
    └── _metadata
```

Now download the dataset via the CLI:

```commandline
$ grizzzly download --author test --name my_dataset --limit 5 
```

## Evaluation
- [x] Make sure this PR contains a single feature
- [x] Make sure this PR solves a Github Issue
- [x] Python Specific:
    * Make sure you added in-code documentation
    * You added Python type hints for parameters and return types