### PR TITLE
GZ-51 Implement INFO endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This document contains a changelog of the relevant `grizzzly` releases.
 
 --
 
+## 0.7.0 - Grizzzly simple info endpoint implementation
+
+* Issue: #51
+* Version: `0.7.0`
+* Feature Scope: `Minor`
+* Date: `2022-05-13`
+
+### Description
+
+This features implements a very simple "info" endpoint.
+
+--
+
 ## 0.6.0 - Grizzzly download endpoint and client implementation
 
 * Issue: #44

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as file:
 
 setup(
     name="grizzzly",
-    version="0.6.0",
+    version="0.7.0",
     description="This is your favorite data sharing library! Works great with pandas.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/src/grizzzly/server/__init__.py
+++ b/src/grizzzly/server/__init__.py
@@ -5,11 +5,13 @@ from flask import Flask
 from grizzzly.server.api_hello import api_hello as hello
 from grizzzly.server.api_upload import api_upload as upload
 from grizzzly.server.api_download import api_download as download
+from grizzzly.server.api_info import api_info as info
 
 # Flask application instance
 app = Flask(__name__)
 
 # Register the endpoints
+app.register_blueprint(info)
 app.register_blueprint(hello)
 app.register_blueprint(upload)
 app.register_blueprint(download)

--- a/src/grizzzly/server/api_info.py
+++ b/src/grizzzly/server/api_info.py
@@ -1,0 +1,27 @@
+import os
+
+import pandas as pd
+from flask import Blueprint, request, jsonify
+
+from grizzzly.server.models import Dataset
+from grizzzly.settings import (
+    GZ_API_DEFAULT_DOWNLOAD_DATASET,
+    GZ_DATASET_STORAGE_PATH,
+)
+
+
+# Create endpoint blueprint
+api_info = Blueprint(
+    name="info",
+    import_name=__name__,
+    url_prefix="/info"
+)
+
+
+# Register endpoints
+@api_info.route("/", methods=["GET"])
+def info():
+    # Global parameters on the query string
+    params = request.args.to_dict()
+    dataset = Dataset.from_requests_args(**params)
+    return jsonify(dataset.info)

--- a/src/grizzzly/server/models.py
+++ b/src/grizzzly/server/models.py
@@ -1,0 +1,50 @@
+import os
+from typing import Dict, List, Optional
+
+from grizzzly.settings import GZ_DATASET_STORAGE_PATH
+
+
+class Dataset:
+
+    def __init__(self, name: str, author: str, obj_id: Optional[str] = None):
+        self.name = name
+        self.author = author
+        self.obj_id = os.listdir(
+            os.path.join(
+                GZ_DATASET_STORAGE_PATH,
+                author,
+                name,
+            )
+        ).pop(0)
+
+    @staticmethod
+    def from_requests_args(**kwargs):
+        name = kwargs.get("name")
+        author = kwargs.get("author")
+        return Dataset(name=name, author=author)
+
+    @property
+    def info(self) -> Dict:
+        return {
+            "author": self.author,
+            "name": self.name,
+            "dataset_id": self.obj_id,
+            "dataset_path": self.get_fullpath(),
+            "partitions": self.partitions,
+        }
+
+    def get_fullpath(self) -> str:
+        return os.path.join(
+            GZ_DATASET_STORAGE_PATH,
+            self.author,
+            self.name,
+            self.obj_id,
+        )
+
+    @property
+    def partitions(self) -> List[str]:
+        return sorted(
+            part
+            for part in os.listdir(self.get_fullpath())
+            if "=" in part
+        )


### PR DESCRIPTION
## Description

This feature implements a simple "info" endpoint to get the dataset partition list.

* Closes #51

## Testing

1. Start the backend server: `grizzzly backend run --debug`
2. Get a "get" request to the following endpoint: http://127.0.0.1:9999/info/ with these parameters:
    - author
    - name

Example of expected output:

```json
{
  "author": "test", 
  "dataset_id": "05153d91-1717-5c86-9e10-5425307215e9", 
  "dataset_path": "[REDACTED]", 
  "name": "my_dataset", 
  "partitions": [
    "gz_chunk_part=0"
  ]
}
```

## Evaluation
- [X] Make sure this PR contains a single feature
- [X] Make sure this PR solves a Github Issue
- [X] Python Specific:
    * Make sure you added in-code documentation
    * You added Python type hints for parameters and return types